### PR TITLE
BOOM-2355: HubSpot API key - no logner supported

### DIFF
--- a/hubspot/build.gradle.kts
+++ b/hubspot/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.goforboom"
-version = "1.1.0"
+version = "1.2.0"
 
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11

--- a/hubspot/src/main/kotlin/com/goforboom/hubspot/model/http/Requester.kt
+++ b/hubspot/src/main/kotlin/com/goforboom/hubspot/model/http/Requester.kt
@@ -19,9 +19,9 @@ object Requester {
         }
 
         // Associate default headers used in every request
-        // https://developers.hubspot.com/docs/api/intro-to-auth
+        // https://developers.hubspot.com/docs/api/private-apps#make-api-calls-with-your-app-s-access-token
         request
-            .queryString("hapikey", client.apiKey)
+            .header("Authorization", "Bearer ${client.apiKey}")
             .withObjectMapper(
                 JacksonObjectMapper(Mapper.objectMapper)
             )


### PR DESCRIPTION
Fixes #4 

Next steps:
- Create private app in hubspot (done for Boom)
- Update the library
- Replace the current api key with the new api key

Changelist:
- replaced `hapiKey` query parameter with `Authorization` header
- increased minor version number